### PR TITLE
Add namespaceFactory option

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -38,10 +38,26 @@ function applyPersistence(vm, option: Option) {
 export function install(Vue: VueConstructor) {
 	Vue.mixin({
 		created() {
+			function cloneOptions(options: Option, ref: any) {
+				const clonedOptions: Option = {
+					keys: [],
+					namespace: ''
+				}
+				for (var prop in options) {
+					if (options.hasOwnProperty(prop)) {
+						if (prop === 'namespaceFactory') {
+							clonedOptions['namespace'] = options[prop](ref)
+						} else {
+							clonedOptions[prop] = options[prop]
+						}
+					}
+				}
+				return clonedOptions
+			}
 			if ('storage' in this.$options) {
-				const option: Option | Option[] = this.$options.storage
-				if (Array.isArray(option)) option.forEach(opt => applyPersistence(this, opt))
-				else applyPersistence(this, option)
+				const options: Option | Option[] = this.$options.storage
+				if (Array.isArray(options)) options.forEach(opt => applyPersistence(this, cloneOptions(opt, this)))
+				else applyPersistence(this, cloneOptions(options, this))
 			}
 		}
 	})

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,6 +8,7 @@ export interface StorageDriver {
 export interface Option {
 	keys: string[]
 	namespace: string
+	namespaceFactory?: ((instance: any) => string)
 	merge?: (obj1: object, ...object) => object //default=internal merge function
 	driver?: StorageDriver //default=localStorageDriver
 }


### PR DESCRIPTION
This PR enables creating component-namespaced store instances like following:

```js
storage: {
        driver: vuejsStorage.drivers.localStorage,
        keys: ['txt'],
        namespace: '',
        namespaceFactory: function (instance) {
            return 'calculator-' + instance.calculator.id; // 'calculator' is component prop
        }
},
```