### PR TITLE
Fix merge when object is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@lucianodltec/vuejs-storage",
 	"description": "Vue.js and Vuex plugin to persistence data with localStorage/sessionStorage",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"main": "./dist/vuejs-storage.cjs.js",
 	"module": "./dist/vuejs-storage.es.js",
 	"browser": "./dist/vuejs-storage.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "vuejs-storage",
+	"name": "@lucianodltec/vuejs-storage",
 	"description": "Vue.js and Vuex plugin to persistence data with localStorage/sessionStorage",
 	"version": "3.1.1",
 	"main": "./dist/vuejs-storage.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vuejs-storage",
 	"description": "Vue.js and Vuex plugin to persistence data with localStorage/sessionStorage",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"main": "./dist/vuejs-storage.cjs.js",
 	"module": "./dist/vuejs-storage.es.js",
 	"browser": "./dist/vuejs-storage.umd.js",

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,5 +1,5 @@
 // a simple object merge function implementation
-export const isobj = x => typeof x === 'object' && !Array.isArray(x) && x !== null
+export const isobj = x => typeof x === 'object' && !Array.isArray(x) && x !== null && x !== undefined
 const merge = (target, source) => {
 	for (const key of Object.keys(source)) {
 		if (isobj(source[key])) {

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -6,7 +6,8 @@ const merge = (target, source) => {
 			if (!(key in target)) {
 				target[key] = source[key]
 			} else {
-				merge(target[key], source[key])
+				const t = target[key] = target[key] || {}
+				merge(t, source[key])
 			}
 		} else {
 			target[key] = source[key]


### PR DESCRIPTION
Please check changes in merge.ts. That allows restoring initial null object from storage.